### PR TITLE
otus-k8s: kubernetes-networks #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: bash
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -102,3 +102,144 @@ kubectl [-n ns] get rolebindings
 
 kubectl auth can-i <verb> <resources> --as <subject> [-n ns]
 ```
+
+# HomeWork 3
+## Что было сделано
+- Для приложения были добавлены проверки: **readinessProbe** и **livenessProbe**.
+- Создан манифест для развертывания приложения в виде Deployment
+- Создан манифест сервиса
+- Kube-proxy в Minikube был перенастроен для работы в режиме ipvs.
+```
+kubectl --namespace kube-system edit configmap/kube-proxy
+kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
+```
+Запуск миникуба: `minikube start  --extra-config=proxy.Mode=ipvs` - не помог, хотя явные отсылки есть в документации (minikube start  --extra-config=proxy.Mode=ipvs).
+- Настроен для работы MetalLB
+    - Для доступа к публикуемым адресам сервисов необходим был роут до них (Пример: `sudo route add 172.17.255.0/24 192.168.99.108`). Возникла проблема с тем что адреса не пингуются. Как оказалось в таблице маршрутизации выше стоял маршрут, созданный докер демоном, который перенавпрялял 172.17.0.0/17 на интерфейс docker0. Квик фикс: удалить маршрут до докера или выбрать альтернативную подсеть.
+    - Выполнено задание со *. Настроен доступ на баллансировщик **coredns**.
+- Настроен для работы Nginx-Ingress контроллер
+    - Частично выполнено задание со * по пробросу dashboard. Вроде все пробрасывается, но экран пустой, WTF.
+    - Выполнено задание по канареечному развертыванию с http заголовками. 
+        - В процессе выполения канареечное разывертывание взлетело только с указанием имени конкретного хоста. Без него nginx-ingress ругался.
+```
+E0728 16:46:32.434479       8 controller.go:1258] cannot merge alternative backend test2-test-svc-8000 into hostname  that does not exist
+```
+
+## Как проверить
+### Применение deployment
+```bash
+minikube start
+cd kubernetes-networks
+kubectl apply -f web-deploy.yaml
+kubectl get deploy
+kubectl get pods
+kubectl describe deployment web
+
+# Просмотр трассировок
+
+kubectl get events --watch
+kubespy trace deploy web
+```
+
+https://ealebed.github.io/posts/2018/%D0%B7%D0%BD%D0%B0%D0%BA%D0%BE%D0%BC%D1%81%D1%82%D0%B2%D0%BE-%D1%81-kubernetes-%D1%87%D0%B0%D1%81%D1%82%D1%8C-5-deployments/
+
+**maxSurge** - необязательное поле, указывающее максимальное количество подов (Pods), которое может быть создано сверх желаемого количества подов (Pods), описанного в развертывании. Значение может быть абсолютным числом (например, 5) или процентом от желаемого количества подов (например, 10%). Значение этого параметра не может быть установлено в 0 и по умолчанию равно 25%.
+
+**maxUnavailable** - необязательное поле, указывающее максимальное количество подов, которые могут быть недоступны в процессе обновления. Значение может быть абсолютным числом (например, 5) или процентом от желаемого количества подов (Pods) (например, 10%). Абсолютное число рассчитывается из процента путем округления. Значение этого параметра не может быть установлено в 0 и по умолчанию равно 25%.
+
+### Настройка сервисов
+```bash
+kubectl apply -f web-svc-cip.yaml 
+kubectl apply -f web-svc-lb.yaml
+kubectl get services
+```
+
+### Настройка IPVS
+
+```bash
+kubectl --namespace kube-system edit configmap/kube-proxy
+--> mode: "ipvs"
+kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
+
+minikube ssh
+toolbox
+dnf install -y ipvsadm && dnf clean all
+```
+
+Пригодившиеся ссылки:
+- https://residentsummer.github.io/posts/2018/08/21/minikube-ipvs/
+- https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/
+- https://kubernetes.io/docs/setup/learning-environment/minikube/ --> https://kubernetes.io/docs/setup/learning-environment/minikube/
+- https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/README.md
+
+### MetalLB
+
+```bash
+kubectl apply -fhttps://raw.githubusercontent.com/google/metallb/v0.8.0/manifests/metallb.yaml
+kubectl apply -f metallb-config.yaml
+sudo route add 172.17.255.0/24 192.168.99.108
+curl http://172.17.255.3
+```
+
+### Задание со * #1
+```bash
+kubectl apply -f coredns-svc-lb.yaml
+```
+**Проверка:**
+
+```bash
+dig @172.17.255.1 web-svc-lb.default.svc.cluster.local +short
+```
+
+### Ingress
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
+
+kubectl apply -f nginx-lb.yaml     
+kubectl apply -f web-svc-headless.yaml
+kubectl apply -f web-ingress.yaml 
+
+kubectl get ingresses/web
+kubectl describe ingresses/web
+```
+
+**Проверка:**
+```bash
+curl -k https://172.17.255.3/web 
+```
+![](https://i.imgur.com/52EXbMK.png)
+
+### Задание со * #2
+```bash
+kubectl apply -f dash-svc-headless.yaml
+kubectl apply -f dash-ingress.yaml
+```
+
+**Проверка**
+curl -k http://172.17.255.3/dashboard
+Ингресс вроде как работает, но непонятно куда копать. В браузере при переходе по ссылке отображается пустая страница с примерно аналогичным содержимым.
+![](https://i.imgur.com/qnElSfU.png)
+
+### Задание со * #3
+```bash
+kubectl apply -f canary-ns-and-pods.yaml
+kubectl apply -f canary-services.yaml
+kubectl apply -f canary-ingress.yaml
+```
+
+**Проверка**
+```bash
+curl --resolve "test.example.com:80:172.17.255.3" http://test.example.com/
+curl --resolve "test.example.com:80:172.17.255.3" -H "canary: true" http://test.example.com/
+```
+![](https://i.imgur.com/CSvf2m6.png)
+
+Без указания хоста почему-то не взлетело. В логах nginx-ingress было следующее:
+```
+E0728 16:46:32.434479       8 controller.go:1258] cannot merge alternative backend test2-test-svc-8000 into hostname  that does not exist
+```
+
+Пригодившиеся ссылки:
+- https://www.elvinefendi.com/2018/11/25/canary-deployment-with-ingress-nginx.html
+- https://medium.com/@domi.stoehr/canary-deployments-on-kubernetes-without-service-mesh-425b7e4cc862
+- https://github.com/stoehdoi/canary-demo?source=post_page---------------------------

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -5,12 +5,6 @@ metadata:
   labels:
     app: web
 spec:
-  containers:
-    - name: web
-      image: fl64/otus-k8s-nginx
-      volumeMounts:
-      - name: app
-        mountPath: /app
   initContainers:
     - name: web-init
       image: busybox:1.31.0
@@ -18,6 +12,26 @@ spec:
       volumeMounts:
       - name: app
         mountPath: /app
+  containers:
+    - name: web
+      image: fl64/otus-k8s-nginx
+      volumeMounts:
+      - name: app
+        mountPath: /app
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      readinessProbe:
+        httpGet:
+          path: /index.html
+          port: 80
+      livenessProbe:
+        tcpSocket:
+          port: 8000
   volumes:
   - name: app
     emptyDir: {}

--- a/kubernetes-networks/canary-ingress.yaml
+++ b/kubernetes-networks/canary-ingress.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels: 
+    app: test1
+  name: test-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+  namespace: test1
+spec:
+  rules:
+  - host: test.example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: test-svc
+          servicePort: 8000
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels: 
+    app: test2
+  name: test-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: canary
+    nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+  namespace: test2
+spec:
+  rules:
+  - host: test.example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: test-svc
+          servicePort: 8000

--- a/kubernetes-networks/canary-ns-and-pods.yaml
+++ b/kubernetes-networks/canary-ns-and-pods.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: test1
+  name: web
+  labels:
+    app: test1
+spec:
+  initContainers:
+    - name: web-init
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://gist.githubusercontent.com/fl64/a06563d5b3e770350e6c02974cd8a5d2/raw/a27a47ee2559cb892cf325fb04ba003adfb5b40e/canary-test-1.sh | sh']
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  containers:
+    - name: web
+      image: fl64/otus-k8s-nginx
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: test2
+  name: web
+  labels:
+    app: test2
+spec:
+  initContainers:
+    - name: web-init
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://gist.githubusercontent.com/fl64/a06563d5b3e770350e6c02974cd8a5d2/raw/a27a47ee2559cb892cf325fb04ba003adfb5b40e/canary-test-2.sh | sh']
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  containers:
+    - name: web
+      image: fl64/otus-k8s-nginx
+      volumeMounts:
+      - name: app
+        mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-networks/canary-services.yaml
+++ b/kubernetes-networks/canary-services.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+  namespace: test1
+spec:
+  selector:
+    app: test1
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-svc
+  namespace: test2
+spec:
+  selector:
+    app: test2
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns-svc-lb.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-lb-udp53
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-lb
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: UDP
+      port: 53
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-lb-tcp53
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns-lb
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 53
+ьштш

--- a/kubernetes-networks/dash-ingress.yaml
+++ b/kubernetes-networks/dash-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: dash
+  namespace: kube-system
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard
+        backend:
+          serviceName: dash-svc
+          servicePort: 9090

--- a/kubernetes-networks/dash-svc-headless.yaml
+++ b/kubernetes-networks/dash-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dash-svc
+  namespace: kube-system
+spec:
+  selector:
+    app: kubernetes-dashboard
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.255.1-172.17.255.255 

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,21 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      initContainers:
+        - name: web-init
+          image: busybox:1.31.0
+          command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+          volumeMounts:
+          - name: app
+            mountPath: /app
+      containers:
+        - name: web
+          image: fl64/otus-k8s-nginx
+          volumeMounts:
+          - name: app
+            mountPath: /app
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
## Что было сделано
- Для приложения были добавлены проверки: **readinessProbe** и **livenessProbe**.
- Создан манифест для развертывания приложения в виде Deployment
- Создан манифест сервиса
- Kube-proxy в Minikube был перенастроен для работы в режиме ipvs.
```
kubectl --namespace kube-system edit configmap/kube-proxy
kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'
```
Запуск миникуба: `minikube start  --extra-config=proxy.Mode=ipvs` - не помог, хотя явные отсылки есть в документации (minikube start  --extra-config=proxy.Mode=ipvs).
- Настроен для работы MetalLB
    - Для доступа к публикуемым адресам сервисов необходим был роут до них (Пример: `sudo route add 172.17.255.0/24 192.168.99.108`). Возникла проблема с тем что адреса не пингуются. Как оказалось в таблице маршрутизации выше стоял маршрут, созданный докер демоном, который перенавпрялял 172.17.0.0/17 на интерфейс docker0. Квик фикс: удалить маршрут до докера или выбрать альтернативную подсеть.
    - Выполнено задание со *. Настроен доступ на баллансировщик **coredns**.
- Настроен для работы Nginx-Ingress контроллер
    - Частично выполнено задание со * по пробросу dashboard. Вроде все пробрасывается, но экран пустой, WTF.
    - Выполнено задание по канареечному развертыванию с http заголовками. 
        - В процессе выполения канареечное разывертывание взлетело только с указанием имени конкретного хоста. Без него nginx-ingress ругался.
```
E0728 16:46:32.434479       8 controller.go:1258] cannot merge alternative backend test2-test-svc-8000 into hostname  that does not exist
```

## Как проверить
### Применение deployment
```bash
minikube start
cd kubernetes-networks
kubectl apply -f web-deploy.yaml
kubectl get deploy
kubectl get pods
kubectl describe deployment web

# Просмотр трассировок

kubectl get events --watch
kubespy trace deploy web
```
### Настройка сервисов
```bash
kubectl apply -f web-svc-cip.yaml 
kubectl apply -f web-svc-lb.yaml
kubectl get services
```

### Настройка IPVS

```bash
kubectl --namespace kube-system edit configmap/kube-proxy
--> mode: "ipvs"
kubectl --namespace kube-system delete pod --selector='k8s-app=kube-proxy'

minikube ssh
toolbox
dnf install -y ipvsadm && dnf clean all
```

Пригодившиеся ссылки:
- https://residentsummer.github.io/posts/2018/08/21/minikube-ipvs/
- https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/
- https://kubernetes.io/docs/setup/learning-environment/minikube/ --> https://kubernetes.io/docs/setup/learning-environment/minikube/
- https://github.com/kubernetes/kubernetes/blob/master/pkg/proxy/ipvs/README.md

### MetalLB

```bash
kubectl apply -fhttps://raw.githubusercontent.com/google/metallb/v0.8.0/manifests/metallb.yaml
kubectl apply -f metallb-config.yaml
sudo route add 172.17.255.0/24 192.168.99.108
curl http://172.17.255.3
```

### Задание со * №1
```bash
kubectl apply -f coredns-svc-lb.yaml
```
**Проверка:**

```bash
dig @172.17.255.1 web-svc-lb.default.svc.cluster.local +short
```
![](https://i.imgur.com/52EXbMK.png)

### Ingress
```bash
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml

kubectl apply -f nginx-lb.yaml     
kubectl apply -f web-svc-headless.yaml
kubectl apply -f web-ingress.yaml 

kubectl get ingresses/web
kubectl describe ingresses/web
```

**Проверка:**
```bash
curl -k https://172.17.255.3/web 
```
### Задание со * №2
```bash
kubectl apply -f dash-svc-headless.yaml
kubectl apply -f dash-ingress.yaml
```
**Проверка**
curl -k http://172.17.255.3/dashboard
- [ ] Ингресс вроде как работает, но непонятно куда копать. В браузере при переходе по ссылке отображается пустая страница с примерно аналогичным содержимым.
![](https://i.imgur.com/qnElSfU.png)

### Задание со * №3
```bash
kubectl apply -f canary-ns-and-pods.yaml
kubectl apply -f canary-services.yaml
kubectl apply -f canary-ingress.yaml
```

**Проверка**
```bash
curl --resolve "test.example.com:80:172.17.255.3" http://test.example.com/
curl --resolve "test.example.com:80:172.17.255.3" -H "canary: true" http://test.example.com/
```
![](https://i.imgur.com/CSvf2m6.png)

- [ ] Без указания хоста почему-то не взлетело. В логах nginx-ingress было следующее:
```
E0728 16:46:32.434479       8 controller.go:1258] cannot merge alternative backend test2-test-svc-8000 into hostname  that does not exist
```

Пригодившиеся ссылки:
- https://www.elvinefendi.com/2018/11/25/canary-deployment-with-ingress-nginx.html
- https://medium.com/@domi.stoehr/canary-deployments-on-kubernetes-without-service-mesh-425b7e4cc862
- https://github.com/stoehdoi/canary-demo?source=post_page---------------------------

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
